### PR TITLE
Allow usage of Ansible module group defaults - for Ansible 2.12+

### DIFF
--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1,2 +1,8 @@
 ---
-requires_ansible: '>=2.9.10'
+requires_ansible: ">=2.9.10"
+action_groups:
+  netapp_aws:
+    - aws_netapp_cvs_active_directory
+    - aws_netapp_cvs_filesystems
+    - aws_netapp_cvs_pool
+    - aws_netapp_cvs_snapshots


### PR DESCRIPTION
##### SUMMARY
Allow usage of Ansible module group defaults

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
https://docs.ansible.com/ansible/latest/user_guide/playbooks_module_defaults.html

##### ADDITIONAL INFORMATION
Allows usage of module defaults like:
```
- hosts: localhost
  connection: local
  gather_facts: false
  collections:
    - netapp.aws
  module_defaults:
    group/netapp.ontap.netapp_aws:
       # common options goes here
```